### PR TITLE
ci(gcb): initial golang build

### DIFF
--- a/.gcb/README.md
+++ b/.gcb/README.md
@@ -1,0 +1,14 @@
+# Google Cloud Build support
+
+This directory contains configuration files and scripts to support GCB (Google
+Cloud Build) builds.
+
+We generally prefer GHA (GitHub Actions) for CI (Continuous Integration):
+building the code, running unit test, run any linters or formatters.
+
+We use GCB is better for CD (Continuous Deployment): creating docker images in
+Google Cloud, and deploying these images to Google Cloud. GCB can perform these
+operations without relatively simple management for authorization and
+permissions. The GCB builds run using a service account specific to our project.
+We can grant these service account the necessary permissions to act on the
+benchmark infrastructure, and nothing else.

--- a/.gcb/README.md
+++ b/.gcb/README.md
@@ -6,9 +6,18 @@ Cloud Build) builds.
 We generally prefer GHA (GitHub Actions) for CI (Continuous Integration):
 building the code, running unit test, run any linters or formatters.
 
-We use GCB is better for CD (Continuous Deployment): creating docker images in
-Google Cloud, and deploying these images to Google Cloud. GCB can perform these
-operations without relatively simple management for authorization and
-permissions. The GCB builds run using a service account specific to our project.
-We can grant these service account the necessary permissions to act on the
-benchmark infrastructure, and nothing else.
+We use GCB for CD (Continuous Deployment): creating docker images in
+Google Cloud, and deploying these images to Google Cloud.
+
+GCB can perform these operations with relatively simple management for
+authentication and authorization. The GCB builds run using a service account
+specific to our project. We can grant this service account the necessary
+permissions to act on the benchmark infrastructure, and nothing else. And we can
+manage these permissions using Terraform, just like we are managing the rest of
+the infrastructure.
+
+In contrast, if we wanted to use GHA for the same role, we would need to either
+(1) download a service account key file and install it as a GHA secret, and
+manually rotate this secret, or (2) configure workload identify federation
+between GitHub and our project. Neither approach is very easy to reason about
+from a security perspective.

--- a/.gcb/cloudbuild.yaml
+++ b/.gcb/cloudbuild.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+options:
+  dynamic_substitutions: true
+  substitutionOption: 'ALLOW_LOOSE'
+
+substitutions:
+  _TAG: 'manual'
+  _WORKDIR: '.'
+
+steps:
+- name: 'gcr.io/kaniko-project/executor:v1.21.1'
+  args: [
+    '--log-format=text',
+    '--cache=true',
+    '--destination=gcr.io/${PROJECT_ID}/w1r3/go:${_TAG}',
+    '--image-fs-extract-retry=3',
+    '--image-download-retry=3',
+    '--push-retry=3',
+    '--context=${_WORKDIR}'
+  ]

--- a/.gcb/infra/.terraform.lock.hcl
+++ b/.gcb/infra/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.21.0"
+  constraints = "~> 5.21.0"
+  hashes = [
+    "h1:6usUS5cjmiWM5GZfLlvPITj2fkKoCg/8apAD2K649vg=",
+    "zh:4185b880504af117898f6b0c50fd8459ac4b9d5fd7c2ceaf6fc5b18d4d920978",
+    "zh:56bbb4ae9cfbd1a9c3008e911605f1edccfa6a1048d88dba0c92f347441d274d",
+    "zh:59246baa783208f5b51ad9d4a4008a327128e234f4a8d1d629cf0af6ae6a9249",
+    "zh:989e7e07a46e486f791a82f20bf0a2f73b64464fe6a97925edc164eeee33d980",
+    "zh:9945cce3c36e4e95c74a2f71c38cb0d042014bef555fdeb07e6d92bc624b7567",
+    "zh:b276a2e6ba9a9d2cd3127b6cc9a9cdf6cca2db1fbe4ad4a5332025ae3c7c9bb6",
+    "zh:d1af7f76ef64a808dcaeabbeb74f27a7925665082209db019ca79e6e06fe3ab2",
+    "zh:d7954e905704b4f158c592e0d8c3d8d54a9edd6f8392d2fa3dfc9f0fe29795d8",
+    "zh:e85724a917887ac00112ca4edafdc2b233c787c2892f386dafa9dfd3215083c0",
+    "zh:ebadb8e5b387914e118ecbf83e08a72d034fe069e9e5b0cefa857b758479f835",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb38ef67430bcf8e07144f77b76b47df35acd38f5e553fe7104ecfe54378bb9e",
+  ]
+}

--- a/.gcb/infra/backend.tf
+++ b/.gcb/infra/backend.tf
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "gcs" {
+    bucket = "storage-sdk-prober-project-terraform"
+    prefix = "gcb"
+  }
+}

--- a/.gcb/infra/build/main.tf
+++ b/.gcb/infra/build/main.tf
@@ -1,0 +1,64 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+variable "region" {}
+
+locals {
+  # Google Cloud Build installs an application on the GitHub organization or
+  # repository. This id is hard-coded here because there is no easy way [^1] to
+  # manage that installation via terraform.
+  #
+  # [^1]: there is a way, described in [Connecting a Gitub host programmatically]
+  #     but I would not call that "easy". It requires (for example) manually
+  #     creating a personally access token (PAT) on GitHub, and storing that
+  #     in the Terraform file.
+  # [Connecting a Gitub host programmatically]: https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#terraform
+  #
+  gcb_app_installation_id = 1168573
+
+  # Google Cloud build stores a secret to access Github in secret manager. The
+  # UI creates a secret name that we record here.
+  gcb_secret_name = "projects/${var.project}/secrets/github-github-oauthtoken-790dbd/versions/latest"
+}
+
+# This is used to retrieve the project number. The project number is embedded in
+# certain P4 (Per-product per-project) service accounts.
+data "google_project" "project" {
+}
+
+resource "google_cloudbuildv2_connection" "github" {
+  project  = var.project
+  location = var.region
+  name     = "github"
+
+  github_config {
+    app_installation_id = local.gcb_app_installation_id
+    authorizer_credential {
+      oauth_token_secret_version = local.gcb_secret_name
+    }
+  }
+}
+
+resource "google_cloudbuildv2_repository" "cpp-storage-prelaunch" {
+  project           = var.project
+  location          = var.region
+  name              = "googleapis-cpp-storage-prelaunch"
+  parent_connection = google_cloudbuildv2_connection.github.name
+  remote_uri        = "https://github.com/googleapis/storage-shared-benchmarking.git"
+}
+
+output "repository" {
+  value = google_cloudbuildv2_repository.cpp-storage-prelaunch.id
+}

--- a/.gcb/infra/main.tf
+++ b/.gcb/infra/main.tf
@@ -1,0 +1,53 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.21.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+# Enable Cloud Build and create triggers.
+module "services" {
+  source  = "./services"
+  project = var.project
+}
+
+# Creates a number of resources needed to run the GCB (Goole Cloud Build)
+# builds. This includes the connection to our GitHub repository, the worker
+# pool, and some buckets to store build caches and logs.
+module "build" {
+  source     = "./build"
+  project    = var.project
+  region     = var.region
+  depends_on = [module.services]
+}
+
+# Enable Cloud Build and create triggers.
+module "triggers" {
+  depends_on = [module.services, module.build]
+  source     = "./triggers"
+  project    = var.project
+  region     = var.region
+  repository = module.build.repository
+}

--- a/.gcb/infra/services/main.tf
+++ b/.gcb/infra/services/main.tf
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+
+resource "google_project_service" "cloudbuild" {
+  project = var.project
+  service = "cloudbuild.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}
+
+resource "google_project_service" "secretmanager" {
+  project = var.project
+  service = "secretmanager.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}

--- a/.gcb/infra/triggers/main.tf
+++ b/.gcb/infra/triggers/main.tf
@@ -1,0 +1,72 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+variable "region" {}
+variable "repository" {}
+
+locals {
+  builds = {
+    w1r3-go = {
+      workdir = "w1r3/go"
+    }
+  }
+}
+
+resource "google_cloudbuild_trigger" "pull-request" {
+  for_each = tomap(local.builds)
+  location = var.region
+  name     = "${each.key}-pr"
+  filename = ".gcb/cloudbuild.yaml"
+  tags     = ["pull-request", "name:${each.key}"]
+
+  repository_event_config {
+    repository = var.repository
+    pull_request {
+      branch          = "^main$"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+
+  substitutions = {
+    _BUILD_NAME = lookup(each.value, "name", "${each.key}")
+    _WORKDIR    = each.value.workdir
+    _TAG        = "pr"
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}
+
+resource "google_cloudbuild_trigger" "post-merge" {
+  for_each = tomap(local.builds)
+  location = var.region
+  name     = "${each.key}-pm"
+  filename = ".gcb/cloudbuild.yaml"
+  tags     = ["post-merge", "push", "name:${each.key}"]
+
+  repository_event_config {
+    repository = var.repository
+    push {
+      branch = "^main$"
+    }
+  }
+
+  substitutions = {
+    _BUILD_NAME = lookup(each.value, "name", "${each.key}")
+    _WORKDIR    = each.value.workdir
+    _TAG        = "latest"
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}

--- a/.gcb/infra/variables.tf
+++ b/.gcb/infra/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  default = "storage-sdk-prober-project"
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+variable "zone" {
+  default = "us-central1-f"
+}

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,4 @@
+# A .ignore file for Google Cloud Build
+
+# Ignore anything ignored by `git`:
+#!include:.gitignore

--- a/w1r3/go/Dockerfile
+++ b/w1r3/go/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.22 AS build
+
+WORKDIR /var/tmp/build/w1r3
+COPY go.mod go.sum /var/tmp/build/w1r3/
+RUN go mod download
+COPY main.go /var/tmp/build/w1r3/
+RUN go build
+
+FROM golang:1.22 AS deploy
+
+RUN apt update && \
+    apt install -y ca-certificates
+
+COPY --from=build /var/tmp/build/w1r3/w1r3 /r/w1r3


### PR DESCRIPTION
Create Google Cloud Build triggers to build the Docker image for
`w1r3/go`. There is quite a bit of infrastructure that (fortunately)
will be shared by the Java and C++ versions of these benchmarks.