### PR TITLE
cleanup(w1r3): match instance count in go deployment

### DIFF
--- a/w1r3/infra/mig/java/main.tf
+++ b/w1r3/infra/mig/java/main.tf
@@ -128,7 +128,7 @@ resource "google_compute_region_instance_group_manager" "default" {
     name              = "primary"
   }
   base_instance_name = local.base_instance_name
-  target_size        = 3
+  target_size        = var.replicas
 
   # NOTE: the name of this resource must be unique for every update;
   #       this is why we have a app_version in the name; this way

--- a/w1r3/infra/variables.tf
+++ b/w1r3/infra/variables.tf
@@ -25,8 +25,9 @@ variable "zone" {
 }
 
 variable "replicas" {
-  # Matches the number of zones in the region.
-  default = 4
+  # TODO(#80) - run one instance per region. Setting this to 4 did not work as
+  #     I (coryan@) expected.
+  default = 3
 }
 
 # use `-var=app_version_go=v2` to redeploy when the changes do not trigger


### PR DESCRIPTION
Fixes #78 