### PR TITLE
feat(w1r3/java): report allocated bytes per byte in Instrumentation

### DIFF
--- a/w1r3/infra/mig/java/main.tf
+++ b/w1r3/infra/mig/java/main.tf
@@ -86,7 +86,7 @@ write_files:
 
     Environment="HOME=/home/cloudservice"
     ExecStartPre=/usr/bin/docker-credential-gcr configure-docker ; /usr/bin/docker pull gcr.io/${var.project}/w1r3/java:latest
-    ExecStart=/usr/bin/docker run --rm -u 2000 --name=w1r3-java-%i gcr.io/${var.project}/w1r3/java:latest java -jar /r/w1r3.jar -project-id ${var.project} -bucket ${var.bucket} -iterations ${local.iterations} -deployment mig -workers 1
+    ExecStart=/usr/bin/docker run --rm -u 2000 --name=w1r3-java-%i gcr.io/${var.project}/w1r3/java:latest java -Xms1g -Xmx1g -XX:+AlwaysPreTouch -XX:MaxDirectMemorySize=1g -Dio.grpc.netty.shaded.io.netty.maxDirectMemory=1073741824 -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal -jar /r/w1r3.jar -project-id ${var.project} -bucket ${var.bucket} -iterations ${local.iterations} -deployment mig -workers 1
     ExecStop=/usr/bin/docker stop w1r3-java-%i
     ExecStopPost=/usr/bin/docker rm w1r3-java-%i
 

--- a/w1r3/infra/mig/java/main.tf
+++ b/w1r3/infra/mig/java/main.tf
@@ -86,7 +86,22 @@ write_files:
 
     Environment="HOME=/home/cloudservice"
     ExecStartPre=/usr/bin/docker-credential-gcr configure-docker ; /usr/bin/docker pull gcr.io/${var.project}/w1r3/java:latest
-    ExecStart=/usr/bin/docker run --rm -u 2000 --name=w1r3-java-%i gcr.io/${var.project}/w1r3/java:latest java -Xms1g -Xmx1g -XX:+AlwaysPreTouch -XX:MaxDirectMemorySize=1g -Dio.grpc.netty.shaded.io.netty.maxDirectMemory=1073741824 -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal -jar /r/w1r3.jar -project-id ${var.project} -bucket ${var.bucket} -iterations ${local.iterations} -deployment mig -workers 1
+    ExecStart=/usr/bin/docker run --rm -u 2000 --name=w1r3-java-%i \
+      gcr.io/${var.project}/w1r3/java:latest java \
+        -Xms1g \
+        -Xmx1g \
+        -XX:+AlwaysPreTouch \
+        -XX:MaxDirectMemorySize=1g \
+        -Dio.grpc.netty.shaded.io.netty.maxDirectMemory=1073741824 \
+        -XX:+UnlockDiagnosticVMOptions \
+        -XX:+UnlockExperimentalVMOptions \
+        -XX:+PrintFlagsFinal \
+        -jar /r/w1r3.jar \
+          -project-id ${var.project} \
+          -bucket ${var.bucket} \
+          -iterations ${local.iterations} \
+          -deployment mig \
+          -workers 1
     ExecStop=/usr/bin/docker stop w1r3-java-%i
     ExecStopPost=/usr/bin/docker rm w1r3-java-%i
 

--- a/w1r3/java/src/main/java/W1R3.java
+++ b/w1r3/java/src/main/java/W1R3.java
@@ -195,7 +195,7 @@ final class W1R3 implements Callable<Integer> {
         meter
             .histogramBuilder("ssb/w1r3/memory")
             .setExplicitBucketBoundariesAdvice(makeMemoryHistogramBoundaries())
-            .setUnit("By")
+            .setUnit("1{memory}")
             .build();
 
     Instrumentation instrumentation =

--- a/w1r3/java/src/main/java/runtime/GcEvent.java
+++ b/w1r3/java/src/main/java/runtime/GcEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime;
+
+import com.google.cloud.Tuple;
+import com.google.common.collect.Streams;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class GcEvent {
+
+  private final long count;
+  private final List<MemoryPoolUsage> pre;
+  private final List<MemoryPoolUsage> post;
+
+  private GcEvent(long count, List<MemoryPoolUsage> pre, List<MemoryPoolUsage> post) {
+    this.count = count;
+    this.pre = pre;
+    this.post = post;
+  }
+
+  /**
+   * Number of GC events since the start of the JVM
+   *
+   * @return
+   */
+  public long getCount() {
+    return count;
+  }
+
+  /** Per pool usage breakdown before gc is performed */
+  public List<MemoryPoolUsage> getPre() {
+    return pre;
+  }
+
+  /** Per pool usage breakdown after gc was performed */
+  public List<MemoryPoolUsage> getPost() {
+    return post;
+  }
+
+  public GcEventDiff sub(GcEvent other) {
+    //noinspection UnstableApiUsage
+    return GcEventDiff.of(
+        this.count - other.count,
+        Streams.zip(this.pre.stream(), other.post.stream(), Tuple::of)
+            .map(t -> t.x().sub(t.y()))
+            .collect(Collectors.toList()));
+  }
+
+  public static GcEvent of(long gcCount, List<MemoryPoolUsage> pre, List<MemoryPoolUsage> post) {
+    return new GcEvent(gcCount, pre, post);
+  }
+
+  public static final class GcEventDiff {
+    private final long count;
+    private final List<MemoryPoolUsage> pools;
+
+    private GcEventDiff(long count, List<MemoryPoolUsage> pools) {
+      this.count = count;
+      this.pools = pools;
+    }
+
+    public long getCount() {
+      return count;
+    }
+
+    public List<MemoryPoolUsage> getPools() {
+      return pools;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s{count=%d, pools=%s}", this.getClass().getSimpleName(), count, pools);
+    }
+
+    public static GcEventDiff of(long count, List<MemoryPoolUsage> diffs) {
+      return new GcEventDiff(count, diffs);
+    }
+  }
+}

--- a/w1r3/java/src/main/java/runtime/GcMonitor.java
+++ b/w1r3/java/src/main/java/runtime/GcMonitor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime;
+
+import static com.sun.management.GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION;
+import static java.lang.management.MemoryType.HEAP;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+
+public final class GcMonitor implements NotificationListener {
+
+  private static final Set<String> MONITORED_POOL_NAMES;
+
+  static {
+    TreeSet<String> tmp = new TreeSet<>();
+    List<MemoryPoolMXBean> pools = ManagementFactory.getMemoryPoolMXBeans();
+    for (MemoryPoolMXBean pool : pools) {
+      if (pool.getType() == HEAP) {
+        tmp.add(pool.getName());
+      }
+    }
+    MONITORED_POOL_NAMES = Collections.unmodifiableSet(tmp);
+  }
+
+  private static final GcMonitor INSTANCE = new GcMonitor();
+
+  static {
+    // must happen after the singleton instance is initialized
+    GcMonitor.register();
+  }
+
+  private final Semaphore sem = new Semaphore(0);
+  private final AtomicLong gcCount = new AtomicLong(0);
+  private final AtomicReference<GcEvent> last = new AtomicReference<>();
+
+  private volatile boolean update;
+
+  private GcMonitor() {}
+
+  @Override
+  public void handleNotification(Notification notification, Object handback) {
+    if (!update) {
+      return;
+    }
+    gcCount.getAndIncrement();
+    Object userData = notification.getUserData();
+    if (notification.getType().equals(GARBAGE_COLLECTION_NOTIFICATION)
+        && userData instanceof CompositeData) {
+      CompositeData data = (CompositeData) userData;
+      GarbageCollectionNotificationInfo gcni = GarbageCollectionNotificationInfo.from(data);
+      GcInfo gcInfo = gcni.getGcInfo();
+      Map<String, MemoryUsage> before = gcInfo.getMemoryUsageBeforeGc();
+      Map<String, MemoryUsage> after = gcInfo.getMemoryUsageAfterGc();
+      GcEvent gcEvent =
+          GcEvent.of(
+              gcCount.get(),
+              MONITORED_POOL_NAMES.stream()
+                  .map(poolName -> MemoryPoolUsage.of(poolName, HEAP, before.get(poolName)))
+                  .collect(Collectors.toList()),
+              MONITORED_POOL_NAMES.stream()
+                  .map(poolName -> MemoryPoolUsage.of(poolName, HEAP, after.get(poolName)))
+                  .collect(Collectors.toList()));
+      last.set(gcEvent);
+    }
+    sem.release(sem.getQueueLength());
+  }
+
+  private GcEvent internalAwaitGc() throws InterruptedException {
+    try {
+      update = true;
+      Runtime.getRuntime().gc();
+      sem.acquire();
+      return last.get();
+    } finally {
+      update = false;
+    }
+  }
+
+  public static GcEvent awaitGc() throws InterruptedException {
+    return INSTANCE.internalAwaitGc();
+  }
+
+  private static void register() {
+    List<GarbageCollectorMXBean> garbageCollectorMXBeans =
+        ManagementFactory.getGarbageCollectorMXBeans();
+    for (GarbageCollectorMXBean gcBean : garbageCollectorMXBeans) {
+      if (gcBean instanceof NotificationEmitter) {
+        NotificationEmitter emitter = (NotificationEmitter) gcBean;
+        emitter.addNotificationListener(INSTANCE, null, null);
+      }
+    }
+  }
+}

--- a/w1r3/java/src/main/java/runtime/Instrumentation.java
+++ b/w1r3/java/src/main/java/runtime/Instrumentation.java
@@ -16,9 +16,16 @@
 
 package runtime;
 
+import com.google.cloud.Tuple;
+import com.google.common.collect.Streams;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
+import java.io.IOException;
+import java.lang.management.MemoryType;
 import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import runtime.GcEvent.GcEventDiff;
 
 public final class Instrumentation {
 
@@ -26,13 +33,19 @@ public final class Instrumentation {
 
   private final DoubleHistogram latencyHistogram;
   private final DoubleHistogram cpuPerByteHistogram;
+  private final DoubleHistogram allocatedBytesPerByteHistogram;
 
-  public Instrumentation(DoubleHistogram latencyHistogram, DoubleHistogram cpuPerByteHistogram) {
+  public Instrumentation(
+      DoubleHistogram latencyHistogram,
+      DoubleHistogram cpuPerByteHistogram,
+      DoubleHistogram allocatedBytesPerByteHistogram) {
     this.latencyHistogram = latencyHistogram;
     this.cpuPerByteHistogram = cpuPerByteHistogram;
+    this.allocatedBytesPerByteHistogram = allocatedBytesPerByteHistogram;
   }
 
-  public Measurement measure(long objectSize, Attributes attributes) {
+  public Measurement measure(long objectSize, Attributes attributes)
+      throws IOException, InterruptedException {
     return new Measurement(objectSize, attributes);
   }
 
@@ -47,26 +60,61 @@ public final class Instrumentation {
 
     private final long beginNs;
     private final long beginCpuNs;
+    private final GcEvent beginGcEvent;
+    private final List<MemoryPoolUsage> beginMemoryPoolUsages;
+    private final SetSize beginRss;
 
-    public Measurement(long objectSize, Attributes attributes) {
+    public Measurement(long objectSize, Attributes attributes)
+        throws IOException, InterruptedException {
       this.objectSize = objectSize;
       this.attributes = attributes;
+      this.beginRss = SmapsRollup.get();
+      this.beginMemoryPoolUsages = MemoryPools.getUsage();
+      this.beginGcEvent = GcMonitor.awaitGc();
       this.beginCpuNs = CpuTime.getTotalCpuNanos();
       this.beginNs = System.nanoTime();
     }
 
-    public void report() {
+    public void report() throws IOException, InterruptedException {
+      // read all of our instruments
       long endNs = System.nanoTime();
       long endCpuNs = CpuTime.getTotalCpuNanos();
+      GcEvent endGcEvent = GcMonitor.awaitGc();
+      List<MemoryPoolUsage> endMemoryPoolUsages = MemoryPools.getUsage();
+      SetSize endRss = SmapsRollup.get();
 
+      // calculate differences from begin
       long elapsed = endNs - beginNs;
       long diffCpuNs = endCpuNs - beginCpuNs;
 
+      SetSize deltaSetSize = endRss.sub(beginRss);
+      GcEventDiff gcEventDiff = endGcEvent.sub(beginGcEvent);
+      //noinspection UnstableApiUsage
+      List<MemoryPoolUsage> pools =
+          Streams.zip(endMemoryPoolUsages.stream(), beginMemoryPoolUsages.stream(), Tuple::of)
+              .map(t -> t.x().sub(t.y()))
+              .collect(Collectors.toList());
+
+      long heapUsed =
+          gcEventDiff.getPools().stream()
+              .mapToLong(MemoryPoolUsage::getUsed)
+              .filter(l -> l > 0)
+              .sum();
+      long nonHeapUsed =
+          pools.stream()
+              .filter(mpu -> mpu.getType() == MemoryType.NON_HEAP)
+              .mapToLong(MemoryPoolUsage::getUsed)
+              .filter(l -> l > 0)
+              .sum();
+      long bytesAllocated = Math.max(0L, heapUsed + (deltaSetSize.getRss()) - nonHeapUsed);
+
       double latencyS = elapsed / NANOS_PER_SECOND;
       double cpuPerByte = ((double) diffCpuNs) / objectSize;
+      double allocatedBytesPerByte = ((double) bytesAllocated) / objectSize;
 
       latencyHistogram.record(latencyS, attributes);
       cpuPerByteHistogram.record(cpuPerByte, attributes);
+      allocatedBytesPerByteHistogram.record(allocatedBytesPerByte, attributes);
     }
   }
 }

--- a/w1r3/java/src/main/java/runtime/SetSize.java
+++ b/w1r3/java/src/main/java/runtime/SetSize.java
@@ -26,10 +26,12 @@ public final class SetSize {
     this.pss = pss;
   }
 
+  /** Number of bytes for the Resident Set Size */
   public long getRss() {
     return rss;
   }
 
+  /** Number of bytes for the Proportional Set Size */
   public long getPss() {
     return pss;
   }

--- a/w1r3/java/src/main/java/runtime/SmapsRollup.java
+++ b/w1r3/java/src/main/java/runtime/SmapsRollup.java
@@ -50,6 +50,7 @@ public final class SmapsRollup {
         break;
       }
     }
-    return new SetSize(rss, pss);
+    // convert from kB to B
+    return new SetSize(rss * 1000, pss * 1000);
   }
 }


### PR DESCRIPTION
Update java terraform config to explicitly set heap size, direct memory size and netty memory size. Limiting the heap will ensure the heap doesn't resize and make it look like one download suddenly doubled the RSS. Limiting direct and netty memory ensures we bound non-heap memory we can/will use.

There is still JVM memory we are not able to account for that will be reflected in RSS but not any of our memory pools. This is low level JVM overhead itself, often GC internal state tracking and other "actually running code" types of things. This memory tends toward zero when the JVM is run long enough, and things reach a steady state.

For allocation, we are not include non-heap usage such as metaspace, or the jvm code cache. The JVM itself is what allocates into these pools, while we have some impact early in the process by triggering some code loading we do not have control of what it's JIT compiler and other optimization logic does.

While the numbers reported for `ssb/w1r3/memory` are not 100% accounted for, they are a pretty good representation of what our code does in order to accomplish the work of uploading/downloading an object. When the JVM first starts up, these numbers are fairly noisy, but once the JVM reaches a steady state they are much less noisy.
