### PR TITLE
feat(w1r3/cpp): add memory usage metrics

### DIFF
--- a/w1r3/cpp/.clang-format
+++ b/w1r3/cpp/.clang-format
@@ -30,7 +30,10 @@ IncludeCategories:
   Priority: 1000
 - Regex: '^<absl/'
   Priority: 1000
+  # Put the regex for "system" headers first, they need to go to the bottom.
 - Regex: '^<sys/[A-Za-z0-9_]*\.h>$'
+  Priority: 10000
+- Regex: '^<[A-Za-z0-9_]*\.h>$'
   Priority: 10000
 - Regex: '^<.*\.h>'
   Priority: 2000


### PR DESCRIPTION
Instrument the C++ benchmark to measure memory allocated during each
operation. That tells us how much memory overhead the client has. It
does not tell us what the actual maximum memory usage is, as the client
may allocate and release memory before allocating some more.

Measuring things was getting convoluted and repetitive, time to refactor
this to a helper.

Part of the work for #121