### PR TITLE
cleanup(w1r3): use regional instance templates

### DIFF
--- a/w1r3/README.md
+++ b/w1r3/README.md
@@ -53,15 +53,15 @@ force a deployment using:
 
 - C++
   ```shell
-  gcloud beta compute instance-groups managed  --project=storage-sdk-prober-project rolling-action restart --region=us-central1 cpp-runner-v1
+  gcloud beta compute instance-groups managed  --project=storage-sdk-prober-project rolling-action restart --region=us-central1 w1r3-cpp-runner-v1
   ```
 - Go
   ```shell
-  gcloud beta compute instance-groups managed  --project=storage-sdk-prober-project rolling-action restart --region=us-central1 go-runner-v1
+  gcloud beta compute instance-groups managed  --project=storage-sdk-prober-project rolling-action restart --region=us-central1 w1r3-go-runner-v1
   ```
 - Java
   ```shell
-  gcloud beta compute instance-groups managed  --project=storage-sdk-prober-project rolling-action restart --region=us-central1 java-runner-v1
+  gcloud beta compute instance-groups managed  --project=storage-sdk-prober-project rolling-action restart --region=us-central1 w1r3-java-runner-v1
   ```
 
 ## Updating the infrastructure

--- a/w1r3/infra/mig/cpp/main.tf
+++ b/w1r3/infra/mig/cpp/main.tf
@@ -40,15 +40,16 @@ variable "app_version" {
 locals {
   # Including the version in the name simplifies updates. An `apply` will
   # delete the previous version and create a new one.
-  runner-template    = "cpp-runner-template-${var.app_version}"
-  runner-group       = "cpp-runner-${var.app_version}"
+  runner-template    = "w1r3-cpp-runner-template-"
+  runner-group       = "w1r3-cpp-runner-${var.app_version}"
   base_instance_name = "w1r3-cpp"
   cpus               = 4
   iterations         = 1000000
 }
 
-resource "google_compute_instance_template" "default" {
-  name = local.runner-template
+resource "google_compute_region_instance_template" "default" {
+  name_prefix = local.runner-template
+  region      = var.region
   disk {
     auto_delete  = true
     boot         = true
@@ -105,7 +106,6 @@ EOF
     network    = "default"
     subnetwork = "default"
   }
-  region = var.region
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"
@@ -125,7 +125,7 @@ resource "google_compute_region_instance_group_manager" "default" {
   name   = local.runner-group
   region = var.region
   version {
-    instance_template = google_compute_instance_template.default.id
+    instance_template = google_compute_region_instance_template.default.id
     name              = "primary"
   }
   base_instance_name = local.base_instance_name

--- a/w1r3/infra/mig/go/main.tf
+++ b/w1r3/infra/mig/go/main.tf
@@ -40,15 +40,16 @@ variable "app_version" {
 locals {
   # Including the version in the name simplifies updates. An `apply` will
   # delete the previous version and create a new one.
-  runner-template    = "go-runner-template-${var.app_version}"
-  runner-group       = "go-runner-${var.app_version}"
+  runner-template    = "w1r3-go-runner-template-"
+  runner-group       = "w1r3-go-runner-${var.app_version}"
   base_instance_name = "w1r3-go"
   cpus               = 4
   iterations         = 1000000
 }
 
-resource "google_compute_instance_template" "default" {
-  name = local.runner-template
+resource "google_compute_region_instance_template" "default" {
+  name_prefix = local.runner-template
+  region      = var.region
   disk {
     auto_delete  = true
     boot         = true
@@ -105,7 +106,6 @@ EOF
     network    = "default"
     subnetwork = "default"
   }
-  region = var.region
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"
@@ -125,7 +125,7 @@ resource "google_compute_region_instance_group_manager" "default" {
   name   = local.runner-group
   region = var.region
   version {
-    instance_template = google_compute_instance_template.default.id
+    instance_template = google_compute_region_instance_template.default.id
     name              = "primary"
   }
   base_instance_name = local.base_instance_name

--- a/w1r3/infra/mig/java/main.tf
+++ b/w1r3/infra/mig/java/main.tf
@@ -40,15 +40,16 @@ variable "app_version" {
 locals {
   # Including the version in the name simplifies updates. An `apply` will
   # delete the previous version and create a new one.
-  runner-template    = "java-runner-template-${var.app_version}"
-  runner-group       = "java-runner-${var.app_version}"
+  runner-template    = "w1r3-java-runner-template-"
+  runner-group       = "w1r3-java-runner-${var.app_version}"
   base_instance_name = "w1r3-java"
   cpus               = 4
   iterations         = 1000000
 }
 
-resource "google_compute_instance_template" "default" {
-  name = local.runner-template
+resource "google_compute_region_instance_template" "default" {
+  name_prefix = local.runner-template
+  region      = var.region
   disk {
     auto_delete  = true
     boot         = true
@@ -120,7 +121,6 @@ EOF
     network    = "default"
     subnetwork = "default"
   }
-  region = var.region
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"
@@ -140,7 +140,7 @@ resource "google_compute_region_instance_group_manager" "default" {
   name   = local.runner-group
   region = var.region
   version {
-    instance_template = google_compute_instance_template.default.id
+    instance_template = google_compute_region_instance_template.default.id
     name              = "primary"
   }
   base_instance_name = local.base_instance_name


### PR DESCRIPTION
Using regional instance templates will make it easier to run the
benchmarks in more than one region. I took the opportunity to rename the
instance groups. Now they all start with `w1r3-*`. I believe that makes
it easier to find the instance groups in the dashboards.

Part of the work for #136 