### PR TITLE
fix(w1r3): better CPU histogram buckets

### DIFF
--- a/w1r3/cpp/w1r3.cc
+++ b/w1r3/cpp/w1r3.cc
@@ -566,10 +566,10 @@ auto make_cpu_histogram_boundaries() {
   std::vector<double> boundaries;
   // The units are ns/B, we start with increments of 0.1ns.
   auto boundary = 0.0;
-  auto increment = 0.1;
+  auto increment = 1.0 / 8.0;
   for (int i = 0; i != 200; ++i) {
     boundaries.push_back(boundary);
-    if (i != 0 && i % 100 == 0) increment *= 2;
+    if (i != 0 && i % 32 == 0) increment *= 2;
     boundary += increment;
   }
   return boundaries;

--- a/w1r3/go/main.go
+++ b/w1r3/go/main.go
@@ -652,10 +652,10 @@ func cpuHistogramBoundaries() []float64 {
 	boundaries := make([]float64, 0)
 	// The units are ns/B, we start with increments of 0.1ns.
 	boundary := 0.0
-	increment := 0.1
+	increment := 1.0 / 8.0
 	for i := range 200 {
 		boundaries = append(boundaries, boundary)
-		if i != 0 && i%100 == 0 {
+		if i != 0 && i%32 == 0 {
 			increment *= 2
 		}
 		boundary += increment

--- a/w1r3/java/src/main/java/W1R3.java
+++ b/w1r3/java/src/main/java/W1R3.java
@@ -461,10 +461,10 @@ final class W1R3 implements Callable<Integer> {
     int numBuckets = 200;
     ArrayList<Double> boundaries = new ArrayList<>(numBuckets);
     double boundary = 0.0;
-    double increment = 0.1;
+    double increment = 1.0 / 8.0;
     for (int i = 0; i < numBuckets; i++) {
       boundaries.add(boundary);
-      if (i != 0 && i % 100 == 0) {
+      if (i != 0 && i % 32 == 0) {
         increment *= 2;
       }
       boundary += increment;


### PR DESCRIPTION
The existing approach stopped around 30ns, and sometimes we use more CPU
per byte (think: small objects).

Fixes #137 