### PR TITLE
chore(w1r3/java): remove workers argument from java benchmark

### DIFF
--- a/w1r3/infra/mig/java/main.tf
+++ b/w1r3/infra/mig/java/main.tf
@@ -102,8 +102,7 @@ write_files:
           -project-id ${var.project} \
           -bucket ${var.bucket} \
           -iterations ${local.iterations} \
-          -deployment mig \
-          -workers 1
+          -deployment mig
     ExecStop=/usr/bin/docker stop w1r3-java-%i
     ExecStopPost=/usr/bin/docker rm w1r3-java-%i
 


### PR DESCRIPTION
Now that we're measuring CPU usage, we will only run with one worker, so we are able to properly attribute the cpu usage.