### PR TITLE
chore(w1r3/java): configure logging to write to stderr

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,6 +55,15 @@
       ],
       "semanticCommitType": "deps",
       "semanticCommitScope": null
+    },
+    {
+      "groupName": "logging dependencies",
+      "packagePatterns": [
+        "^org.slf4j:",
+        "^ch.qos.logback:"
+      ],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
     }
   ]
 }

--- a/w1r3/java/pom.xml
+++ b/w1r3/java/pom.xml
@@ -73,6 +73,22 @@
             <artifactId>detector-resources</artifactId>
             <version>0.27.0-alpha</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.6</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/w1r3/java/src/main/java/W1R3.java
+++ b/w1r3/java/src/main/java/W1R3.java
@@ -200,7 +200,11 @@ final class W1R3 implements Callable<Integer> {
       Transport[] transports, Uploader[] uploaders, byte[] randomData, Random random, Otel otel) {
     LOGGER.trace(
         "worker(transports : {}, uploaders : {}, randomData.length : {}, random : {}, otel : {})",
-        transports, uploaders, randomData.length, random, otel);
+        transports,
+        uploaders,
+        randomData.length,
+        random,
+        otel);
     var tracer = otel.getBaseTracer();
     var meter = otel.getBaseMeter();
     var latencyHistogram =

--- a/w1r3/java/src/main/java/W1R3.java
+++ b/w1r3/java/src/main/java/W1R3.java
@@ -33,6 +33,9 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import otel_support.Otel;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -45,6 +48,12 @@ import runtime.Instrumentation;
     version = "",
     description = "Runs the w1r3 benchmark.")
 final class W1R3 implements Callable<Integer> {
+  static {
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(W1R3.class);
   private static final String SERVICE_NAME = "w1r3";
   private static final String SCOPE_NAME = "w1r3";
   private static final String SCOPE_VERSION = "0.0.1";
@@ -91,7 +100,9 @@ final class W1R3 implements Callable<Integer> {
   private Integer[] objectSizes;
 
   public static void main(String... args) {
+    LOGGER.trace("main(args : {})", Arrays.toString(args));
     var exitCode = new CommandLine(new W1R3()).execute(args);
+    LOGGER.info("exitCode = {}", exitCode);
     System.exit(exitCode);
   }
 
@@ -187,6 +198,9 @@ final class W1R3 implements Callable<Integer> {
 
   private void worker(
       Transport[] transports, Uploader[] uploaders, byte[] randomData, Random random, Otel otel) {
+    LOGGER.trace(
+        "worker(transports : {}, uploaders : {}, randomData.length : {}, random : {}, otel : {})",
+        transports, uploaders, randomData.length, random, otel);
     var tracer = otel.getBaseTracer();
     var meter = otel.getBaseMeter();
     var latencyHistogram =

--- a/w1r3/java/src/main/resources/logback.xml
+++ b/w1r3/java/src/main/resources/logback.xml
@@ -101,7 +101,7 @@
   <logger name="com.google.cloud.storage" level="warn"/>
 
   <!-- this benchmark's appender -->
-  <logger name="W1R3" level="trace"/>
+  <logger name="W1R3" level="info"/>
 
   <root level="info">
     <appender-ref ref="STDERR"/>

--- a/w1r3/java/src/main/resources/logback.xml
+++ b/w1r3/java/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2030 Google LLC
+  ~ Copyright 2024 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/w1r3/java/src/main/resources/logback.xml
+++ b/w1r3/java/src/main/resources/logback.xml
@@ -1,0 +1,109 @@
+<!--
+  ~ Copyright 3030 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <!-- grpc thread name pattern is 'grpc-default-worker-ELG-1-' (26 char) plus digit -->
+      <pattern>%date %-5.5level [%-30.30thread] %-16.16logger{16} - %message%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="NOEXCEPTION" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <!-- grpc thread name pattern is 'grpc-default-worker-ELG-1-' (26 char) plus digit -->
+      <pattern>%date %-5.5level [%-30.30thread] %-16.16logger{16} - %message%nopex%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="com.google.auth.oauth2.ComputeEngineCredentials" level="info"/>
+  <logger name="io.grpc.ChannelLogger" level="info"/>
+  <!-- Context logs an exception when it's not able to find things, so suppress it's exception -->
+  <logger name="io.grpc.Context" level="info" additivity="false">
+    <appender-ref ref="NOEXCEPTION"/>
+  </logger>
+  <logger name="io.grpc.auth.GoogleAuthLibraryCallCredentials" level="info" additivity="false">
+    <appender-ref ref="NOEXCEPTION"/>
+  </logger>
+  <logger name="io.grpc.LoadBalancerRegistry" level="warn"/>
+  <logger name="io.grpc.NameResolverRegistry" level="warn"/>
+  <!--
+  GrpclbNameResolver logs an exception with several of it's messages that aren't
+  useful when you're only interested in the traffic
+  -->
+  <logger name="io.grpc.grpclb.GrpclbNameResolver" level="info" additivity="false">
+    <appender-ref ref="NOEXCEPTION"/>
+  </logger>
+  <logger name="io.grpc.ManagedChannelRegistry" level="info" additivity="false">
+    <appender-ref ref="NOEXCEPTION"/>
+  </logger>
+  <logger name="io.grpc.internal.ManagedChannelImplBuilder" level="info" additivity="false">
+    <appender-ref ref="NOEXCEPTION"/>
+  </logger>
+  <logger name="io.grpc.internal.AbstractManagedChannelImplBuilder" level="warn"/>
+  <logger name="io.grpc.internal.DnsNameResolver" level="warn"/>
+  <!--
+  netty initialization and event loop management appenders,
+  not necessarily what is desired when debugging requests
+  -->
+  <logger name="io.grpc.netty.shaded.io.grpc.netty" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.buffer" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.channel.DefaultChannelId" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.channel.MultithreadEventLoopGroup" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.handler.ssl" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.NetUtil" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.Recycler" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.ResourceLeakDetector" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.ResourceLeakDetectorFactory" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.internal.CleanerJava6" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.internal.InternalThreadLocalMap" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryLoader" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0" level="warn"/>
+  <logger name="io.perfmark.PerfMark" level="warn"/>
+  <!--
+  jdk11 appender which includes lots of details about ssl cypher suites
+  -->
+  <logger name="jdk.event.security" level="warn"/>
+  <!-- http request logging -->
+  <logger name="sun.net.www.protocol.http.HttpURLConnection" level="warn"/>
+  <logger name="com.google.api.client.http.HttpTransport" level="warn"/>
+  <!-- grpc netty traffic logging -->
+  <logger name="io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler" level="warn"/>
+  <logger name="io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler" level="warn"/>
+
+  <!-- google-c2p related appenders -->
+  <logger name="io.grpc.googleapis.GoogleCloudToProdNameResolver" level="warn"/>
+  <logger name="io.grpc.internal.JndiResourceResolverFactory$JndiResourceResolver" level="warn"/>
+  <logger name="io.grpc.util.MultiChildLoadBalancer" level="warn"/>
+  <logger name="io.grpc.xds.WeightedRoundRobinLoadBalancer" level="warn"/>
+  <logger name="io.grpc.xds.XdsCredentialsRegistry" level="warn"/>
+  <logger name="io.grpc.xds.XdsLogger" level="warn"/>
+
+  <!-- google-cloud-storage appender -->
+  <logger name="com.google.cloud.storage" level="warn"/>
+
+  <!-- this benchmark's appender -->
+  <logger name="W1R3" level="trace"/>
+
+  <root level="info">
+    <appender-ref ref="STDERR"/>
+  </root>
+</configuration>

--- a/w1r3/java/src/main/resources/logback.xml
+++ b/w1r3/java/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 3030 Google LLC
+  ~ Copyright 2030 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
Explicitly depend on SLF4J (rather than the implicit dependency from otel logging), and include jul-to-slf4j to route all java util logging to SLF4j.

Add runtime scoped dependency on logback-classic to provide the SLF4J backend. Add logback.xml to configure the logback appenders to write to stderr, and turn down logging for many grpc/netty internal classes (in the event debugging is necessary, these levels can be increased).

Leave benchmark informational statements on stdout to allow easy separation of program output from logs.