### PR TITLE
fix(w1r3/java): make gc event calculation null safe

### DIFF
--- a/w1r3/java/src/main/java/runtime/GcEvent.java
+++ b/w1r3/java/src/main/java/runtime/GcEvent.java
@@ -20,6 +20,7 @@ import com.google.cloud.Tuple;
 import com.google.common.collect.Streams;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class GcEvent {
 
@@ -55,7 +56,10 @@ public final class GcEvent {
     return post;
   }
 
-  public GcEventDiff sub(GcEvent other) {
+  public GcEventDiff sub(@Nullable GcEvent other) {
+    if (other == null) {
+      return GcEventDiff.of(timestampNs, count, post);
+    }
     //noinspection UnstableApiUsage
     return GcEventDiff.of(
         this.timestampNs - other.timestampNs,

--- a/w1r3/java/src/main/java/runtime/GcMonitor.java
+++ b/w1r3/java/src/main/java/runtime/GcMonitor.java
@@ -97,7 +97,7 @@ public final class GcMonitor implements NotificationListener {
     final long begin = System.nanoTime();
     Runtime.getRuntime().gc();
     GcEvent gcEvent;
-    while ((gcEvent = last.get()).getTimestampNs() < begin) {
+    while ((gcEvent = last.get()) != null && gcEvent.getTimestampNs() < begin) {
       long split = System.nanoTime();
       if (split - begin > SLEEP_MAX_TIMEOUT) {
         // if we can't get a new value within 5 second, break out and return what we have


### PR DESCRIPTION
On the very first operation it is possible the GcEvent will be null for its begin. Update things so null doesn't result in a NullPointerException.