### PR TITLE
feat: record benchmark version

### DIFF
--- a/.gcb/cloudbuild.yaml
+++ b/.gcb/cloudbuild.yaml
@@ -29,5 +29,6 @@ steps:
     '--image-fs-extract-retry=3',
     '--image-download-retry=3',
     '--push-retry=3',
-    '--context=${_WORKDIR}'
+    '--context=.',
+    '--dockerfile=${_WORKDIR}/Dockerfile'
   ]

--- a/w1r3/cpp/Dockerfile
+++ b/w1r3/cpp/Dockerfile
@@ -63,8 +63,9 @@ RUN apk update && \
 RUN ldconfig /usr/local/lib*
 
 WORKDIR /var/tmp/build/w1r3
-COPY CMakeLists.txt w1r3.cc /var/tmp/build/w1r3/
-RUN cmake -G Ninja -S . -B .build -DCMAKE_BUILD_TYPE=Release && \
+COPY .git/ /var/tmp/build/w1r3/.git
+COPY w1r3/ /var/tmp/build/w1r3/w1r3
+RUN cmake -G Ninja -S w1r3/cpp -B .build -DCMAKE_BUILD_TYPE=Release && \
     cmake --build .build
 
 # RUN ldd .build/w1r3 && false
@@ -76,5 +77,3 @@ RUN apk update && \
             boost1.84-program_options libcurl crc32c
 
 COPY --from=build /var/tmp/build/w1r3/.build/w1r3 /r/w1r3
-
-RUN ldd /r/w1r3

--- a/w1r3/go/Dockerfile
+++ b/w1r3/go/Dockerfile
@@ -15,14 +15,14 @@
 FROM golang:1.22 AS build
 
 WORKDIR /var/tmp/build/w1r3
-COPY go.mod go.sum /var/tmp/build/w1r3/
-RUN go mod download
-COPY main.go /var/tmp/build/w1r3/
-RUN go build
+COPY w1r3/ /var/tmp/build/w1r3/w1r3
+RUN go -C w1r3/go mod download
+COPY .git/ /var/tmp/build/w1r3/.git
+RUN go -C w1r3/go build
 
 FROM golang:1.22 AS deploy
 
 RUN apt update && \
     apt install -y ca-certificates
 
-COPY --from=build /var/tmp/build/w1r3/w1r3 /r/w1r3
+COPY --from=build /var/tmp/build/w1r3/w1r3/go/w1r3 /r/w1r3

--- a/w1r3/java/Dockerfile
+++ b/w1r3/java/Dockerfile
@@ -15,16 +15,17 @@
 FROM maven:3.9.8-eclipse-temurin-11 AS build
 
 WORKDIR /var/tmp/build
-COPY pom.xml /var/tmp/build/
+COPY w1r3/java/pom.xml /var/tmp/build/w1r3/java/pom.xml
 # Manually install the dependencies to speed up the builds on Cloud Build.
 # Kaniko caches this layer and the build does not need to download the
 # dependencies each time.
-RUN mvn dependency:resolve-plugins
-RUN mvn dependency:resolve
-RUN mvn install
-COPY src/main /var/tmp/build/src/main
-RUN mvn package
+RUN env -C w1r3/java mvn dependency:resolve-plugins
+RUN env -C w1r3/java mvn dependency:resolve
+RUN env -C w1r3/java mvn install
+COPY .git/ /var/tmp/build/.git
+COPY w1r3/ /var/tmp/build/w1r3
+RUN env -C w1r3/java mvn package
 
 FROM eclipse-temurin:21.0.4_7-jdk-jammy
 
-COPY --from=build  /var/tmp/build/target/w1r3-0.0.1-SNAPSHOT.jar /r/w1r3.jar
+COPY --from=build  /var/tmp/build/w1r3/java/target/w1r3-0.0.1-SNAPSHOT.jar /r/w1r3.jar


### PR DESCRIPTION
Preserve the `.git/` directory in the GCB builds so we can capture the benchmark version and include this in the metric attributes.

C++ and Go already capture the version, Java needs more work:

![image](https://github.com/user-attachments/assets/07543460-c4b9-494d-ace6-adb799c3c74c)
